### PR TITLE
Fix template blocks and incident datetime

### DIFF
--- a/AladdinApp/app.py
+++ b/AladdinApp/app.py
@@ -92,6 +92,16 @@ class Incident(db.Model):
     def __repr__(self):
         return f"Incident('{self.title}', '{self.reported_by}', '{self.status}')"
 
+# Define ComplianceFramework model
+class ComplianceFramework(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(255), nullable=False)
+    version = db.Column(db.String(50))
+    description = db.Column(db.Text)
+    regulatory_body = db.Column(db.String(100))
+    is_mandatory = db.Column(db.Boolean, default=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
 # Flask route for homepage
 @app.route('/')
 def index():
@@ -354,14 +364,20 @@ def new_incident():
     if request.method == 'POST':
         title = request.form.get('title')
         description = request.form.get('description')
-        date_occurred = request.form.get('date_occurred')
+        date_occurred_str = request.form.get('date_occurred')
+        date_occurred = datetime.fromisoformat(date_occurred_str) if date_occurred_str else None
         reported_by = request.form.get('reported_by')
         impact = request.form.get('impact')
         corrective_action = request.form.get('corrective_action')
 
-        new_incident = Incident(title=title, description=description,
-                                date_occurred=date_occurred, reported_by=reported_by,
-                                impact=impact, corrective_action=corrective_action)
+        new_incident = Incident(
+            title=title,
+            description=description,
+            date_occurred=date_occurred,
+            reported_by=reported_by,
+            impact=impact,
+            corrective_action=corrective_action,
+        )
 
         db.session.add(new_incident)
         db.session.commit()
@@ -380,7 +396,8 @@ def edit_incident(id):
     if request.method == 'POST':
         incident.title = request.form.get('title')
         incident.description = request.form.get('description')
-        incident.date_occurred = request.form.get('date_occurred')
+        date_occurred_str = request.form.get('date_occurred')
+        incident.date_occurred = datetime.fromisoformat(date_occurred_str) if date_occurred_str else None
         incident.reported_by = request.form.get('reported_by')
         incident.status = request.form.get('status')
         incident.impact = request.form.get('impact')
@@ -408,7 +425,8 @@ def delete_incident(id):
 @app.route('/compliance')
 @login_required
 def compliance():
-    return render_template('compliance/index.html')
+    frameworks = ComplianceFramework.query.all()
+    return render_template('compliance/index.html', frameworks=frameworks)
 
 # Flask route for policies page
 @app.route('/policies')

--- a/AladdinApp/run.sh
+++ b/AladdinApp/run.sh
@@ -1,1 +1,2 @@
-pip install -r reqs.txt
+#!/bin/bash
+pip install -r requirements.txt

--- a/AladdinApp/templates/base.html
+++ b/AladdinApp/templates/base.html
@@ -189,7 +189,7 @@
                         </div>
                         {% block auth_content %}
                         {% if not current_user.is_authenticated %}
-                            {% block content %}{% endblock %}
+                            {% block guest_content %}{% endblock %}
                         {% endif %}
                         {% endblock %}
                     </div>

--- a/AladdinApp/templates/login.html
+++ b/AladdinApp/templates/login.html
@@ -2,7 +2,7 @@
 
 {% block title %}Login - Aladdin GRC{% endblock %}
 
-{% block content %}
+{% block guest_content %}
 <!-- Flash Messages -->
 {% with messages = get_flashed_messages(with_categories=true) %}
     {% if messages %}
@@ -51,4 +51,4 @@
         Default admin credentials: admin / admin
     </small>
 </div>
-{% endblock %}
+{% endblock guest_content %}

--- a/AladdinApp/templates/register.html
+++ b/AladdinApp/templates/register.html
@@ -3,7 +3,7 @@
 
 {% block title %}Register - Aladdin GRC{% endblock %}
 
-{% block content %}
+{% block guest_content %}
 <!-- Flash Messages -->
 {% with messages = get_flashed_messages(with_categories=true) %}
     {% if messages %}
@@ -54,4 +54,4 @@
         <i class="fas fa-sign-in-alt"></i> Login Here
     </a>
 </div>
-{% endblock %}
+{% endblock guest_content %}


### PR DESCRIPTION
## Summary
- rename guest blocks in base template to avoid duplication
- adjust login/register templates to override `guest_content`
- correct run script to use `requirements.txt`
- parse incident datetime fields and add ComplianceFramework model
- provide frameworks list to compliance page
- remove stray file

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6882114161c0832f89abeaaf96a34871